### PR TITLE
fix(build.gradle): bump version kotlin to 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.0.0-rc-1036'
+    ext.kotlin_version = '1.0.0'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
Kotlin 1.0 Release Candidate is Out! :tada: 
http://blog.jetbrains.com/kotlin/2016/02/kotlin-1-0-release-candidate-is-out/
